### PR TITLE
Resolve Iris, Tgrade prefix and "panic: pubkey is incorrect size" problems

### DIFF
--- a/td2/chain-details.go
+++ b/td2/chain-details.go
@@ -13,7 +13,8 @@ import (
 // altValopers is used to get a bech32 prefix for chains using non-standard naming
 var altValopers = &valoperOverrides{
 	Prefixes: map[string]string{
-		"ival": "ica", // Iris hub
+		"iva": "ica", // Iris hub
+		"tgrade": "tgrade", // Tgrade
 
 		// TODO: was told tgrade also has a custom prefix, but not sure what the pair is
 		// "tval": "tvalcons",

--- a/td2/validator.go
+++ b/td2/validator.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256r1"
+	"github.com/tendermint/tendermint/crypto"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
 	slashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -12,6 +15,12 @@ import (
 	"strings"
 	"time"
 )
+
+type CryptoKey interface {
+	Marshal() (dAtA []byte, err error)
+	Unmarshal(dAtA []byte) error
+	Address() crypto.Address
+}
 
 // ValInfo holds most of the stats/info used for secondary alarms. It is refreshed roughly every minute.
 type ValInfo struct {
@@ -151,7 +160,15 @@ func getVal(ctx context.Context, client *rpchttp.HTTP, valoper string) (pub []by
 	if err != nil {
 		return
 	}
-	pk := ed25519.PubKey{}
+	var pk CryptoKey
+	var keyType string = val.Validator.ConsensusPubkey.TypeUrl
+	if keyType == "/cosmos.crypto.ed25519.PubKey" {
+		pk = &ed25519.PubKey{}
+	} else if keyType == "/cosmos.crypto.secp256k1.PubKey" {
+		pk = &secp256k1.PubKey{}
+	} else {
+		pk = &secp256r1.PubKey{}
+	}
 	err = pk.Unmarshal(val.Validator.ConsensusPubkey.Value)
 	if err != nil {
 		return


### PR DESCRIPTION
### Resolve Iris, Tgrade prefix problem
Update and Add Iris, Tgrade alternative valoper prefix
```
"iva": "ica", // Iris hub
"tgrade": "tgrade", // Tgrade
```

### Resolve `panic: pubkey is incorrect size`(#34) problem
Support not only `ed25519` but also `secp256k1` and `secp256r1` for deriving key